### PR TITLE
Support for pkg-config

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,9 @@ prefix = @prefix@
 
 SUBDIRS = lib libmisc examples collector probe
 
+pkgconfigdir = @libdir@/pkgconfig
+INST_PKGCONFIG = libipfix.pc
+
 .PHONY: subdirs $(SUBDIRS)
 
 all: subdirs
@@ -25,10 +28,17 @@ examples collector probe: lib libmisc
 $(SUBDIRS):
 	$(MAKE) -C $@ $(filter-out $(SUBDIRS),$(MAKECMDGOALS))
 
-clean install uninstall: subdirs
+install: subdirs
+	@[ -d $(DESTDIR)/${pkgconfigdir} ] || (mkdir -p $(DESTDIR)/${pkgconfigdir}; chmod 755 $(DESTDIR)/${pkgconfigdir})
+	cp $(INST_PKGCONFIG) $(DESTDIR)/${pkgconfigdir}/
+
+clean: subdirs
+
+uninstall: subdirs
+	rm -f $(addprefix $(DESTDIR)${pkgconfigdir}/, $(INST_PKGCONFIG))
 
 distclean: subdirs
-	rm -rf config.status config.log Makefile
+	rm -rf config.status config.log Makefile config.h libipfix.pc
 
 # build binary package
 # to build signed package remove -us -uc

--- a/configure
+++ b/configure
@@ -4781,7 +4781,7 @@ fi
 done
 
 
-ac_config_files="$ac_config_files Makefile lib/Makefile libmisc/Makefile probe/Makefile examples/Makefile collector/Makefile"
+ac_config_files="$ac_config_files Makefile lib/Makefile libmisc/Makefile probe/Makefile examples/Makefile collector/Makefile libipfix.pc"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5473,6 +5473,7 @@ do
     "probe/Makefile") CONFIG_FILES="$CONFIG_FILES probe/Makefile" ;;
     "examples/Makefile") CONFIG_FILES="$CONFIG_FILES examples/Makefile" ;;
     "collector/Makefile") CONFIG_FILES="$CONFIG_FILES collector/Makefile" ;;
+    "libipfix.pc") CONFIG_FILES="$CONFIG_FILES libipfix.pc" ;;
 
   *) as_fn_error "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -232,5 +232,6 @@ AC_CONFIG_FILES([Makefile \
            libmisc/Makefile \
            probe/Makefile \
            examples/Makefile \
-           collector/Makefile ])
+           collector/Makefile \
+           libipfix.pc ])
 AC_OUTPUT

--- a/libipfix.pc.in
+++ b/libipfix.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libipfix
+Description: A C-Library for the IPFIX protocol
+URL: http://www.ip-measurement.org/libipfix
+Version: @PACKAGE_VERSION@
+Requires:
+Libs: -L${libdir} -lipfix @LDFLAGS@ @LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi,

You seem to be doing a lot of work on libipfix, which is great! I've added support for pkg-config, which is very useful when linking and compiling with the library when it is distributed as a package, in case you are interested.

Kind regards,
Luca Boccassi
