### PR TITLE
Added ipfix_init_with_start_time function

### DIFF
--- a/lib/ipfix.c
+++ b/lib/ipfix.c
@@ -678,6 +678,17 @@ int ipfix_get_eno_ieid( char *field, int *eno, int *ieid )
  */
 int ipfix_init( void )
 {
+    time_t tstart = time(NULL);
+    return ipfix_init_with_start_time(tstart);
+}
+
+/*
+ * name:        ipfix_init_with_start_time()
+ * parameters:  > tstart  time_t from which to calculate system uptime
+ * remarks:     init module, read field type info.
+ */
+int ipfix_init_with_start_time( time_t tstart )
+{
     /* check and store in global flag, 
      * whether we are on a Small or BigEndian machine */
     testEndianness(); 
@@ -693,7 +704,7 @@ int ipfix_init( void )
         return -1;
     }
 #endif
-    g_tstart = time(NULL);
+    g_tstart = tstart;
     signal( SIGPIPE, SIG_IGN );
     g_lasttid = 255;
 

--- a/lib/ipfix.h
+++ b/lib/ipfix.h
@@ -243,6 +243,7 @@ extern int ipfix_snprint_ipaddr( char *str, size_t size, void *data, size_t len 
 /** common funcs
  */
 int  ipfix_init( void );
+int  ipfix_init_with_start_time( time_t tstart );
 int  ipfix_add_vendor_information_elements( ipfix_field_type_t *fields );
 int  ipfix_reload( void );
 void ipfix_cleanup( void );


### PR DESCRIPTION
ipfix_init always uses the current time for the start time, which is not
ideal and means that we can't control the exported uptime. The
ipfix_init_with_start_time function takes a time_t to calculate uptime
from.

Signed-off-by: James Wheatley jwheatle@brocade.com
